### PR TITLE
Update ErrorRegExp to handle colons and whitespace after the word 'Error'

### DIFF
--- a/cause/record.js
+++ b/cause/record.js
@@ -1,5 +1,5 @@
 const { Record, fromJS } = require("immutable");
-const ErrorRegExp = /^Error\n(?:\s+at[^\n]+\n){2}\s+at\s+([^\(]+\(([^\)]+)[^\n]+)/;
+const ErrorRegExp = /^Error:?\s*\n(?:\s+at[^\n]+\n){2}\s+at\s+([^\(]+\(([^\)]+)[^\n]+)/;
 const LocationRegExp = /^.+\:\d+\:\d+$/;
 const constructors = Object.create(null);
 const type = object => Object.getPrototypeOf(object).constructor;


### PR DESCRIPTION
The ErrorRegExp was failing on this stack trace:

```
Error: 
    at module.exports (<redacted>/@cause/cause/record.js:10:56)
    at Event (<redacted>/@cause/cause/cause.js:12:5)
    at Map.map (<redacted>/@cause/cause/cause.js:83:31)
    at <redacted>/immutable/dist/immutable.js:3016:46
    at List.__iterate (<redacted>/immutable/dist/immutable.js:2206:13)
    at IndexedIterable.mappedSequence.__iterateUncached (<redacted>/immutable/dist/immutable.js:3015:23)
    at seqIterate (<redacted>/immutable/dist/immutable.js:604:16)
    at IndexedIterable.IndexedSeq.__iterate (<redacted>/immutable/dist/immutable.js:320:14)
    at IndexedIterable.toArray (<redacted>/immutable/dist/immutable.js:4258:23)
    at List [as constructor] (<redacted>/immutable/dist/immutable.js:2065:62)
```